### PR TITLE
Fix: Truncated meeting code

### DIFF
--- a/js/attendance.js
+++ b/js/attendance.js
@@ -260,7 +260,7 @@
     }
 
     function getMeetCode() {
-        return document.title.substring(7)
+        return document.title.substring(6)
     }
 
     function resizeCard() {


### PR DESCRIPTION
Meeting code was always missing the first character.

![image](https://user-images.githubusercontent.com/6750582/93958074-47df9200-fd1b-11ea-8f57-01ac913400ee.png)